### PR TITLE
[FreeBSD]: fixed build on FreeBSD

### DIFF
--- a/busybee_utils.cc
+++ b/busybee_utils.cc
@@ -27,6 +27,9 @@
 
 // POSIX
 #ifndef _MSC_VER
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#endif
 #include <ifaddrs.h>
 #endif
 


### PR DESCRIPTION
I fixed it:

make  all-am
  CXX    busybee_mta.lo
  CXX    busybee_sta.lo
  CXX    busybee_st.lo
  CXX    busybee_mapper.lo
  CXX    busybee_returncode.lo
  CXX    busybee_single.lo
  CXX    busybee_utils.lo
In file included from busybee_utils.cc:31:
/usr/include/ifaddrs.h:34: error: 'u_int' does not name a type
**\* [busybee_utils.lo] Error code 1
